### PR TITLE
Update version to publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 *.min.js
 build
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slush-biojs",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "A slush generator for BioJS modules",
   "keywords": [
     "slushgenerator",


### PR DESCRIPTION
I edited my fork instead of this repo directly, so I'll just pull it in. 

This is just an update of the version number so I can try to publish an new version to npm. The version on npm still has the deprecated 'licenses' field. 