### PR TITLE
move template substitutions to top of the file

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -10,6 +10,7 @@
 // browserify build config
 var buildDir = "build";
 var outputFile = "<%= appNameShort %>";
+var appNameSlug = "<%= appNameSlug %>";
 
 // packages
 var gulp   = require('gulp');
@@ -133,7 +134,7 @@ gulp.task('build-browser',['init'], function() {
 
 // browserify min
 gulp.task('build-browser-min',['init'], function() {
-  var b = browserify({hasExports: true, standalone: "<%= appNameSlug %>"});
+  var b = browserify({hasExports: true, standalone: appNameSlug});
   exposeBundles(b);
   return b.bundle()
     .pipe(source(outputFile + ".min.js"))


### PR DESCRIPTION
I think it improves readability to declare all the local template variables at the top of the file - also helps to avoid issues on refactoring / renaming projects.